### PR TITLE
OrbitControls: Remove duplicate code

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -960,8 +960,6 @@ class OrbitControls extends EventDispatcher {
 
 		function onMouseMove( event ) {
 
-			if ( scope.enabled === false ) return;
-
 			switch ( state ) {
 
 				case STATE.ROTATE:


### PR DESCRIPTION
Related issue: None

**Description**

Both the `onPointerMove()` and `onMouseMove()` method have the judgment of scope.enabled, delete the judgment in `onMouseMove`.
